### PR TITLE
Add compatibility for checkpoints of "Free-form Video Inpainting with 3D Gated Convolution and Temporal PatchGAN"

### DIFF
--- a/src/model/video_inpainting_model.py
+++ b/src/model/video_inpainting_model.py
@@ -39,6 +39,7 @@ class VideoInpaintingModel(BaseModel):
         self.conv_type = opts['conv_type'] if 'conv_type' in opts else 'gated'
 
         self.use_refine = opts['use_refine'] if 'use_refine' in opts else False
+        use_skip_connection = opts.get('use_skip_connection', False)
 
         self.opts = opts
 
@@ -47,7 +48,7 @@ class VideoInpaintingModel(BaseModel):
         ######################
         self.generator = Generator(
             nc_in, nc_out, nf, use_bias, norm, self.conv_by, self.conv_type,
-            use_refine=self.use_refine)
+            use_refine=self.use_refine, use_skip_connection=use_skip_connection)
 
         #################
         # Discriminator #

--- a/src/scripts/FVI_checkpoint_compatibility_transform.py
+++ b/src/scripts/FVI_checkpoint_compatibility_transform.py
@@ -1,0 +1,57 @@
+# import sys
+# import os.path as op
+# sys.path.append(op.join(op.pardir, __file__))  # noqa
+
+import re
+import argparse
+from collections import OrderedDict
+
+import torch
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        """
+        IMPORTANT NOTE: to run this script, you need to put it under src/ instead of src/scripts
+        due to some unpickling issues of torch.load()
+
+        This script is to modify a checkpoint saved in our previous "FVI with Gated Conv" repository.
+        1. Add a "use_skip_connection=True" tag in the "arch/args/opts" entry in the config json.
+        2. Replace names of nn modules that has been changed during the LGTSM development.
+        """
+    )
+    parser.add_argument('--src', type=str, required=True)
+    parser.add_argument('--dst', type=str, required=True)
+    args = parser.parse_args()
+    return args
+
+
+def rename_conv_to_featureConv(checkpoint):
+    state_dict = checkpoint['state_dict']
+    # modified_keys = [k for k, v in state_dict.keys() if 'temporal_discriminator' in k and '.conv.' in k]
+    new_state_dict = OrderedDict([
+        (k.replace('.conv.', '.featureConv.'), v)
+        if 'temporal_discriminator' in k and '.conv.' in k else (k, v)
+        for k, v in state_dict.items()
+    ])
+    new_metadata = OrderedDict([
+        (re.sub(r'.conv$', '.featureConv', k), v)
+        if 'temporal_discriminator' in k and '.conv' in k else (k, v)
+        for k, v in state_dict._metadata.items()
+    ])
+    setattr(new_state_dict, '_metadata', new_metadata)
+    checkpoint['state_dict'] = new_state_dict
+    return checkpoint
+
+
+def main():
+    args = parse_args()
+    breakpoint()
+    checkpoint = torch.load(args.src)
+    new_checkpoint = rename_conv_to_featureConv(checkpoint)
+    new_checkpoint['config']['arch']['args']['opts']['use_skip_connection'] = True
+    torch.save(new_checkpoint, args.dst)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/scripts/FVI_checkpoint_compatibility_transform.py
+++ b/src/scripts/FVI_checkpoint_compatibility_transform.py
@@ -16,8 +16,9 @@ def parse_args():
         due to some unpickling issues of torch.load()
 
         This script is to modify a checkpoint saved in our previous "FVI with Gated Conv" repository.
-        1. Add a "use_skip_connection=True" tag in the "arch/args/opts" entry in the config json.
-        2. Replace names of nn modules that has been changed during the LGTSM development.
+        What it will do:
+            1. Add a "use_skip_connection=True" tag in the "arch/args/opts" entry in the config json.
+            2. Replace names of nn modules that has been changed during the LGTSM development.
         """
     )
     parser.add_argument('--src', type=str, required=True)

--- a/src/scripts/FVI_checkpoint_compatibility_transform.py
+++ b/src/scripts/FVI_checkpoint_compatibility_transform.py
@@ -1,7 +1,3 @@
-# import sys
-# import os.path as op
-# sys.path.append(op.join(op.pardir, __file__))  # noqa
-
 import re
 import argparse
 from collections import OrderedDict
@@ -29,7 +25,6 @@ def parse_args():
 
 def rename_conv_to_featureConv(checkpoint):
     state_dict = checkpoint['state_dict']
-    # modified_keys = [k for k, v in state_dict.keys() if 'temporal_discriminator' in k and '.conv.' in k]
     new_state_dict = OrderedDict([
         (k.replace('.conv.', '.featureConv.'), v)
         if 'temporal_discriminator' in k and '.conv.' in k else (k, v)
@@ -47,11 +42,14 @@ def rename_conv_to_featureConv(checkpoint):
 
 def main():
     args = parse_args()
-    breakpoint()
+    print(f'\nLoading the old checkpoint from {args.src}')
     checkpoint = torch.load(args.src)
+    print('\nRenaming state_dict keys and adding the skip connection tag')
     new_checkpoint = rename_conv_to_featureConv(checkpoint)
     new_checkpoint['config']['arch']['args']['opts']['use_skip_connection'] = True
+    print(f'\nSaving the modified checkpoint into {args.dst}')
     torch.save(new_checkpoint, args.dst)
+    print('\nDone')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Why do we need this PR?
* Checkpoints saved from another repo for "Free-form Video Inpainting with 3D Gated Convolution and Temporal PatchGAN" can't be loaded directly due to a nn.module renaming issue and the removal of skip connection in `UpSampleModule`

## How is it implemented?
* Write a python script to transform a checkpoint:
  * Replace those keys in state_dict that have been renamed
  * Add a tag to inform that the model of this checkpoint is using skip connection
* Add back the compatibility of skip connection


#### PR readiness check list
> - [ v ] Did it pass the Flake8 check?
> - [ v ] Did you test this PR?  
