### PR TITLE
Add structures to old checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please see [training](doc/training.md)
 1. Download corresponding pretrained weights from [Google Drive](https://drive.google.com/open?id=1uva9yI8yYKivqi4pWcyZLcCdIt1k-LRY)
     * The weights for the ICCV 2019 work
         * The one trained on FVI dataset is under `FFVI_3DGatedConv+TPGAN_trained_on_FVI_dataset` as well as its training config.
-    * The weights for the BMVC 2019 work (LGTSM):
+    * The weights for the BMVC 2019 work (LGTSM)
         * The one trained on FVI dataset is named as `v0.2.3_GatedTSM_inplace_noskip_b2_back_L1_vgg_style_TSMSNTPD128_1_1_10_1_VOR_allMasks_load135_e135_pdist0.1256`
         * For the one trained on FaceForensics, please refer to `Readme`
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Therefore, in "Learnable Gated Temporal Shift Module for Deep Video Inpainting. 
 ![block](doc/block_stacking.png)
 
 
-This repository contains source code for both works. Some pretrained weights for the GTSM one are given, while the LGTSM code could be found in the LGTSM branch. The pretrained weights of the 3DGated model is not available now due to some compatibility issues. The implementation of the baseline CombCN is also provided.
+This repository contains source code for both works. Some pretrained weights for the GTSM one are given, while the LGTSM code could be found in the LGTSM branch. The implementation of the baseline CombCN is also provided.
 
 ![compare](doc/fig_compare.png)
 ## Environment Setup
@@ -42,6 +42,12 @@ Please see [training](doc/training.md)
 
 ## Testing
 1. Download corresponding pretrained weights from [Google Drive](https://drive.google.com/open?id=1uva9yI8yYKivqi4pWcyZLcCdIt1k-LRY)
+    * The weights for the ICCV 2019 work
+        * The one trained on FVI dataset is under `FFVI_3DGatedConv+TPGAN_trained_on_FVI_dataset` as well as its training config.
+    * The weights for the BMVC 2019 work (LGTSM):
+        * The one trained on FVI dataset is named as `v0.2.3_GatedTSM_inplace_noskip_b2_back_L1_vgg_style_TSMSNTPD128_1_1_10_1_VOR_allMasks_load135_e135_pdist0.1256`
+        * For the one trained on FaceForensics, please refer to `Readme`
+
 2. Update parameters in `src/other_configs/inference_example.json`:
     * If you want to test on other data, set `root_masks_dir` for testing masks and `root_videos_dir` for testing frames.
     * If you want to turn on evaluation, set `evaluate_score` to `true`.

--- a/src/model/loss.py
+++ b/src/model/loss.py
@@ -209,7 +209,7 @@ class CompleteFramesReconLoss(nn.Module):
 
 # From https://github.com/phoenix104104/fast_blind_video_consistency
 class TemporalWarpingLoss(nn.Module):
-    def __init__(self, flownet_checkpoint_path, alpha=50):
+    def __init__(self, flownet_checkpoint_path=None, alpha=50):
         super().__init__()
         self.loss_fn = L1LossMaskedMean()
         self.alpha = alpha

--- a/src/scripts/FVI_checkpoint_compatibility_transform.py
+++ b/src/scripts/FVI_checkpoint_compatibility_transform.py
@@ -19,6 +19,10 @@ def parse_args():
     )
     parser.add_argument('--src', type=str, required=True)
     parser.add_argument('--dst', type=str, required=True)
+    parser.add_argument(
+        '--add_course_net_structures', action='store_true',
+        help='For those older checkpoint, there\'s no "Generator.CourseNet" structures. '
+             'Set this arg to add it manually.')
     args = parser.parse_args()
     return args
 
@@ -40,13 +44,52 @@ def rename_conv_to_featureConv(checkpoint):
     return checkpoint
 
 
+def add_course_net_structures(checkpoint):
+    state_dict = checkpoint['state_dict']
+    downsample_conv_names = [
+        'conv1', 'conv2', 'conv3', 'conv4', 'conv5', 'conv6',
+        'dilated_conv1', 'dilated_conv2', 'dilated_conv3', 'dilated_conv4',
+        'conv7', 'conv8'
+    ]
+    upsample_conv_names = [
+        'conv9', 'conv10', 'conv11', 'deconv1', 'deconv2'
+    ]
+
+    def transform(k, v):
+        if any([k.startswith(name) for name in upsample_conv_names]):
+            out = ('generator.coarse_net.upsample_module.' + k, v)
+        elif any([k.startswith(name) for name in downsample_conv_names]):
+            out = ('generator.coarse_net.downsample_module.' + k, v)
+        else:
+            out = (k, v)
+        return out
+
+    new_state_dict = OrderedDict([
+        transform(k, v)
+        for k, v in state_dict.items()
+    ])
+    new_metadata = OrderedDict([
+        transform(k, v)
+        for k, v in state_dict._metadata.items()
+    ])
+    setattr(new_state_dict, '_metadata', new_metadata)
+    checkpoint['state_dict'] = new_state_dict
+    return checkpoint
+
+
 def main():
     args = parse_args()
     print(f'\nLoading the old checkpoint from {args.src}')
     checkpoint = torch.load(args.src)
+
     print('\nRenaming state_dict keys and adding the skip connection tag')
     new_checkpoint = rename_conv_to_featureConv(checkpoint)
     new_checkpoint['config']['arch']['args']['opts']['use_skip_connection'] = True
+
+    if args.add_course_net_structures:
+        print('\nAdding course_net structures into checkpoint')
+        new_checkpoint = add_course_net_structures(new_checkpoint)
+
     print(f'\nSaving the modified checkpoint into {args.dst}')
     torch.save(new_checkpoint, args.dst)
     print('\nDone')


### PR DESCRIPTION
## Why do we need this PR?
* The old checkpoint has no structures like "generator.course_net.downsample_module.conv1" but just "conv1". We need to add those prefixes into the `state_dict`'s keys of that ckpt.

* Also, in the config of that checkpoint there is a deprecated loss `TemporalWarpingLoss` which needs `flownet_checkpoint_path` as a positional argument. We need to provide a default value to load that checkpoint.

## Others
* I have added the checkpoint (transformed by `scripts/FVI_checkpoint_compatibility_transform.py`) that we used to report scores on the ICCV2019 paper in the [google drive](https://drive.google.com/open?id=1uva9yI8yYKivqi4pWcyZLcCdIt1k-LRY) we put in the readme.

#### PR readiness check list
> - [ v ] Did it pass the Flake8 check?
> - [ v ] Did you test this PR?  
