### PR TITLE
Remove no-longer existed argument "-mask" in evaluate.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = F403, W503
+ignore = F403, W503, E402
 exclude = 
     .git,
     *migrations*,

--- a/doc/script_usage.md
+++ b/doc/script_usage.md
@@ -31,7 +31,7 @@ bash scripts/run_vcs_baseline.sh object_like /tmp2/yaliangchang/Temporally-Coher
 
 ## An example to evaluate distance between output and ground truth videos
 ```
-python evaluate.py -rgd ../dataset/test_20181109/JPEGImages -rmd ../dataset/random_masks_vl20_ns5_object_like_test/ -rrd saved/VideoInpaintingModel_v0.3.0_l1_m+a_mvgg_style_1_6_0.05_120_0_0_all_mask/0102_214744/test_outputs -mask
+python evaluate.py -rgd ../dataset/test_20181109/JPEGImages -rmd ../dataset/random_masks_vl20_ns5_object_like_test/ -rrd saved/VideoInpaintingModel_v0.3.0_l1_m+a_mvgg_style_1_6_0.05_120_0_0_all_mask/0102_214744/test_outputs
 
 ```
 

--- a/src/base/base_trainer.py
+++ b/src/base/base_trainer.py
@@ -216,7 +216,7 @@ class BaseTrainer:
                 for k in current_state.keys()
                 if k not in pretrained_state.keys()
             ])
-            self.logger.info(f"Allowing lack of submodules for pretrained model.")
+            self.logger.info("Allowing lack of submodules for pretrained model.")
             self.logger.info(f"Submodule(s) not in pretrained model but in current model: {lack_modules}")
             redundant_modules = set([
                 k.split('.')[0]

--- a/src/model/completion_model.py
+++ b/src/model/completion_model.py
@@ -45,7 +45,7 @@ class VideoCN(nn.Module):
             dim_x = x.shape[i]
             dim_y = y.shape[i]
             if dim_x != dim_y:
-                assert dim_x == dim_y + 1, (f'Only deal with the odd width inverse case of deconv. ',
+                assert dim_x == dim_y + 1, ('Only deal with the odd width inverse case of deconv. ',
                                             f'Got dim_x: {dim_x}, dim_y: {dim_y}')
                 output_x = output_x.narrow(i, 0, dim_y)
         return output_x

--- a/src/scripts/extract_frames.py
+++ b/src/scripts/extract_frames.py
@@ -76,7 +76,7 @@ def main(args):
     def signal_handler(signum, frame):
         manager.filepaths = []
         logger.error(
-            f"Got ctrl+c, set manager filepaths = [], please wait until all workers are done"
+            "Got ctrl+c, set manager filepaths = [], please wait until all workers are done"
         )
 
     signal.signal(signal.SIGINT, signal_handler)

--- a/src/scripts/mask_scripts/gen_foresics_masks.py
+++ b/src/scripts/mask_scripts/gen_foresics_masks.py
@@ -54,7 +54,7 @@ def get_random_mask(img_size=[128, 128], r=[0.375, 0.5]):
 
 
 def gen_masks(in_direc, out_direc, args):
-    assert in_direc != out_direc, f'input and output directory should not be the same'
+    assert in_direc != out_direc, 'input and output directory should not be the same'
 
     video_dirs = get_everything_under(in_direc)
     assert all([os.path.isdir(d) for d in video_dirs])

--- a/src/scripts/mask_scripts/gen_masks.py
+++ b/src/scripts/mask_scripts/gen_masks.py
@@ -159,7 +159,7 @@ def copy_masks_without_boarder(root_dir, args):
         return Image.fromarray(pix).convert('1')
 
     wo_boarder_dir = root_dir + '_noBoarder'
-    logger.info(f'Copying all masks')
+    logger.info('Copying all masks')
     shutil.copytree(root_dir, wo_boarder_dir)
 
     for i, filename in enumerate(get_everything_under(wo_boarder_dir)):

--- a/src/trainer/trainer.py
+++ b/src/trainer/trainer.py
@@ -370,8 +370,8 @@ class Trainer(BaseTrainer):
                     self.writer.add_scalar(f'loss_d_{d}', loss_d.item())
 
             self.writer.add_scalar('loss_total', loss_total.item())
-            self.writer.add_scalar(f'loss_gan_s', loss_gan_s.item())
-            self.writer.add_scalar(f'loss_gan_t', loss_gan_t.item())
+            self.writer.add_scalar('loss_gan_s', loss_gan_s.item())
+            self.writer.add_scalar('loss_gan_t', loss_gan_t.item())
 
             with torch.no_grad():
                 total_loss += loss_total.item()

--- a/src/utils/face.py
+++ b/src/utils/face.py
@@ -72,9 +72,9 @@ def connect_landmarks(image_shape, landmarks, color=None, alpha=0.75):
         (j, k) = FACIAL_LANDMARKS_IDXS[name]
         pts = landmarks[j:k]
 
-        for l in range(1, len(pts)):
-            ptA = tuple(pts[l - 1])
-            ptB = tuple(pts[l])
+        for x in range(1, len(pts)):
+            ptA = tuple(pts[x - 1])
+            ptB = tuple(pts[x])
             cv2.line(landmarks_contour, ptA, ptB, color, 2)
 
     # apply the transparent landmarks_contour


### PR DESCRIPTION
## Why do we need this PR?
The issue #23 mentioned that an argument `-mask` of `evaluate.py` described in `doc/script_usage.md` does not exist in `evaluate.py`. After investigation, I found this argument is removed in the old repository because all evaluation should be done along with masks:

![image](https://user-images.githubusercontent.com/17662095/83637514-57a36100-a5da-11ea-9f28-1c5b2d9fc659.png)

So, I remove `-mask` in `doc/script_usage.md` to prevent future confusion.

#### PR readiness check list
[ v ] Did it pass the Flake8 check?
[ v ] Did you test this PR?  
